### PR TITLE
Minor fix for the PropertyValueMapper

### DIFF
--- a/src/main/java/pl/asie/foamfix/common/PropertyValueMapper.java
+++ b/src/main/java/pl/asie/foamfix/common/PropertyValueMapper.java
@@ -39,7 +39,7 @@ public class PropertyValueMapper {
 				bits++;
 				b >>= 1;
 			}
-			this.bits = bits;
+			this.bits = bits-1;
 			int i = 0;
 
 			for (Object o : property.getAllowedValues()) {


### PR DESCRIPTION
It was reserving 1 bit more than necessary for each property, e.g. 2 bits for a 2-state property. Memory usage grows exponentially with bit count, so this saves a fair bit of memory (~274 MB on BTMMoon).