### PR TITLE
Allow some textures to be animated even if tx animation is globally disabled

### DIFF
--- a/src/main/java/pl/asie/foamfix/client/FastTextureAtlasSprite.java
+++ b/src/main/java/pl/asie/foamfix/client/FastTextureAtlasSprite.java
@@ -62,6 +62,7 @@ import pl.asie.foamfix.FoamFix;
 import pl.asie.foamfix.api.IFoamFixSprite;
 import pl.asie.foamfix.shared.FoamFixShared;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class FastTextureAtlasSprite extends TextureAtlasSprite implements IFoamFixSprite {
@@ -74,7 +75,7 @@ public class FastTextureAtlasSprite extends TextureAtlasSprite implements IFoamF
 
     @Override
     public void updateAnimation() {
-        if (FoamFixShared.config.clDisableTextureAnimations)
+        if (FoamFixShared.config.clDisableTextureAnimations && Arrays.stream(FoamFixShared.config.clTextureAnimationsWhitelist).filter(s -> !s.isEmpty()).noneMatch(s -> this.getIconName().startsWith(s)))
             return;
 
         ++tickCounter;

--- a/src/main/java/pl/asie/foamfix/coremod/FoamFixTransformer.java
+++ b/src/main/java/pl/asie/foamfix/coremod/FoamFixTransformer.java
@@ -303,9 +303,6 @@ public class FoamFixTransformer implements IClassTransformer {
             handlerCN.add(new EntityDataManagerPatch(), "net.minecraft.network.datasync.EntityDataManager");
         }
 
-        patchy.addTransformerId("disableTextureAnimations_v1");
-        handlerCN.add(new ReturnIfBooleanTruePatch("clDisableTextureAnimations", "updateAnimations", "func_94248_c"),
-                "net.minecraft.client.renderer.texture.TextureMap");
 
         if (FoamFixShared.config.geFasterHopper) {
             patchy.addTransformerId("fasterHopper_v1");

--- a/src/main/java/pl/asie/foamfix/shared/FoamFixConfig.java
+++ b/src/main/java/pl/asie/foamfix/shared/FoamFixConfig.java
@@ -47,6 +47,7 @@ public class FoamFixConfig {
 	public boolean geDeduplicate, clWipeModelCache, clCleanRedundantModelRegistry, clDynamicItemModels;
 	public boolean clCheapMinimumLighter, clInitOptions, clModelLoaderCleanup;
 	public boolean clParallelModelBaking, clDisableTextureAnimations;
+	public String[] clTextureAnimationsWhitelist;
 	public boolean geBlacklistLibraryTransformers;
 	public boolean geBlockPosPatch, geFasterEntityLookup, geFasterPropertyComparisons, geFasterAirLookup, geFasterEntityDataManager;
 	public boolean twDisableRedstoneLight;
@@ -80,6 +81,18 @@ public class FoamFixConfig {
 	public boolean geSmallLightingOptimize = false;
 
 	public boolean resourceDirty;
+
+
+	private String[] getStrings(String name, String category, String defaultValue, String description, boolean requiresRestart, boolean showInGui) {
+		Property prop = config.get(category, name, defaultValue);
+		prop.setDefaultValue(defaultValue);
+		prop.setComment(description + " [default: " + defaultValue + "]");
+		prop.setRequiresMcRestart(requiresRestart);
+		prop.setShowInGui(showInGui);
+		prop.setLanguageKey("foamfix.config." + name);
+		applicableProperties.add(prop);
+		return prop.getString().split(",");
+	}
 
 	private boolean getBoolean(String name, String category, boolean defaultValue, String description, boolean requiresRestart, boolean showInGui) {
 		Property prop = config.get(category, name, defaultValue);
@@ -190,7 +203,8 @@ public class FoamFixConfig {
 				}
 			}
 
-			clDisableTextureAnimations = getBoolean("disableTextureAnimations", "client", false, "Disables texture animations.", false, true);
+			clDisableTextureAnimations = getBoolean("disableTextureAnimations", "client", false, "Disables texture animations for all textures that are not on the whitelist", false, true);
+			clTextureAnimationsWhitelist = getStrings("textureAnimationsWhitelist", "client", "minecraft:", "Defines which textures should be animated. All textures starting with one of the strings will be allowed. Values separated by ','. Requires 'disableTextureAnimations' to be true", false, true);
 			clInitOptions = getBoolean("initOptions", "client", true, "Initialize the options.txt and forge.cfg files with rendering performance-friendly defaults if not present.", true, false);
 //			clCheapMinimumLighter = getBoolean("cheapMinimumLight", "experimental", true, "Replaces the Minimum Smooth Lighting option with a lighter which only provides ambient occlusion, but not smooth light per se.", true, true);
 			clCheapMinimumLighter = false;


### PR DESCRIPTION
Allows e.g. minecraft's textures to remain animated, while all others are disabled.
This is benificial, as with the default resource pack there aren't that many animated blocks, but you quickly notice the ones that are animated if it is disabled (e.g. Water, Fire)
